### PR TITLE
jQuery and Bootstrap path typos

### DIFF
--- a/webdev/gulp-tasks/javascript.js
+++ b/webdev/gulp-tasks/javascript.js
@@ -42,11 +42,11 @@ gulp.task('javascript:build', function() {
 });
 gulp.task('javascript:vendor', function() {
     return gulp.src([
-        './node_modules/jquery/dist/query.js',
+        './node_modules/jquery/dist/jquery.js',
         './node_modules/popper.js/dist/umd/popper.js',
         './node_modules/select2/dist/js/select2.js',
         './node_modules/select2/dist/js/**/i18n/*.js',
-        './node_modules/bootstrap-beta/dist/js/bootstrap.js'
+        './node_modules/bootstrap/dist/js/bootstrap.js'
     ])
         .pipe(clip())
         .pipe(gulp.dest('./build/Javascript/vendor'))


### PR DESCRIPTION
engage-webdev wasn't building properly because it was missing these changes.